### PR TITLE
Update LiteDbConnection.cs

### DIFF
--- a/src/Hangfire.LiteDB/LiteDbConnection.cs
+++ b/src/Hangfire.LiteDB/LiteDbConnection.cs
@@ -250,6 +250,9 @@ namespace Hangfire.LiteDB
             }
 
             var server = Database.Server.FindById(serverId);
+             if (server == null)
+                    return;
+
             server.LastHeartbeat = DateTime.Now;
             Database.Server.Update(server);
         }


### PR DESCRIPTION
Added null check to avoid Null reference error
Error occurred during execution of 'ServerHeartbeat' process. Execution will be retried (attempt #5) in 00:00:19 seconds. System.NullReferenceException: Object reference not set to an instance of an object. at Hangfire.LiteDB.LiteDbConnection.Heartbeat(String serverId)